### PR TITLE
Updated to Unreal Engine version 5.1

### DIFF
--- a/Source/DetailsMetadataExtension/Private/DetailsMetadataExtensionModule.cpp
+++ b/Source/DetailsMetadataExtension/Private/DetailsMetadataExtensionModule.cpp
@@ -18,6 +18,9 @@ public:
 
     virtual void StartupModule() override;
     virtual void ShutdownModule() override;
+
+private:
+    FDelegateHandle GetVariableCustomizationInstanceDelegateHandle;
 };
 
 //////////////////////////////////////////////////////////////////////////
@@ -33,7 +36,9 @@ void FDetailsMetadataExtensionModule::StartupModule()
 {
     // Register Blueprint editor variable customization
     FBlueprintEditorModule& BlueprintEditorModule = FModuleManager::LoadModuleChecked<FBlueprintEditorModule>("Kismet");
-    BlueprintEditorModule.RegisterVariableCustomization(FProperty::StaticClass(), FOnGetVariableCustomizationInstance::CreateStatic(&FVariableMetadataDetailsCustomization::MakeInstance));
+    GetVariableCustomizationInstanceDelegateHandle = BlueprintEditorModule.RegisterVariableCustomization(
+        FProperty::StaticClass(),
+        FOnGetVariableCustomizationInstance::CreateStatic(&FVariableMetadataDetailsCustomization::MakeInstance));
 }
 
 //--------------------------------------------------------------------------------------------------------------------
@@ -44,7 +49,8 @@ void FDetailsMetadataExtensionModule::ShutdownModule()
     FBlueprintEditorModule* BlueprintEditorModule = FModuleManager::GetModulePtr<FBlueprintEditorModule>("Kismet");
     if (BlueprintEditorModule)
     {
-        BlueprintEditorModule->UnregisterVariableCustomization(FProperty::StaticClass());
+        BlueprintEditorModule->UnregisterVariableCustomization(FProperty::StaticClass(),
+                                                               GetVariableCustomizationInstanceDelegateHandle);
     }
 }
 


### PR DESCRIPTION
Fixed deprecation warning for 'FBlueprintEditorModule::UnregisterVariableCustomization', the used overload was deprecated in Unreal version 5.1